### PR TITLE
feat(sync-schemas): Add schemas sync action

### DIFF
--- a/sync-schemas/README.md
+++ b/sync-schemas/README.md
@@ -1,0 +1,113 @@
+# sync-schemas
+
+Publish a set of JSON schemas owned by one component of a source repo into the central API repo (e.g. `remotivelabs/remotivelabs-apis`).
+
+The action:
+
+1. Mints a short-lived [GitHub App](https://docs.github.com/en/apps/creating-github-apps) installation token scoped to the target repo.
+2. Checks out the target repo and resets a long-lived branch `schemas-sync/<source-repo>-<component>` from `origin/main`.
+3. Copies each listed schema to `schemas/<name>.json` in the target.
+4. Commits, force-pushes the branch with `--force-with-lease`, opens (or reuses) a PR with labels `schemas-sync` and `source:<source-repo>`.
+5. Waits for the PR's checks to pass via `gh pr checks --watch`.
+6. Rebase-merges the PR.
+
+If any of the PR's checks fail, the action fails before merging.
+
+Each source component publishes its own schemas from its release workflow — schema lifecycle = component lifecycle. The per-component branch name keeps concurrent component releases isolated.
+
+## Prerequisites
+
+- A GitHub App installed on the target repo with **Contents: read/write**, **Pull requests: read/write**, **Checks: read**, and **Actions: read** permissions.
+- The App's ID and private key stored as secrets in the source repo (e.g. `DOCS_PUSH_APP_ID`, `DOCS_PUSH_PRIVATE_KEY`).
+- The target repo must allow rebase merges (the action uses `gh pr merge --rebase`).
+- A PR check workflow in the target repo (e.g. a `build-on-pull-request.yaml`) — the action waits for it before merging.
+- Labels `schemas-sync` and `source:<source-repo>` exist on the target repo.
+
+## Usage
+
+```yaml
+- uses: remotivelabs/remotivelabs-topology-actions/sync-schemas@v1
+  with:
+    # GitHub App ID for the docs-sync App.
+    # Required
+    app-id: ""
+    # GitHub App private key (.pem contents).
+    # Required
+    private-key: ""
+    # Name of the central API repo. Assumed to be in the same org as the calling repo.
+    # Required
+    target-repo: ""
+    # Slug identifying the source component owning these schemas (e.g. topology, broker).
+    # Used in the sync branch name (schemas-sync/<source-repo>-<component>) so concurrent
+    # component releases stay isolated, and in the PR title/commit message.
+    # Required
+    source-component: ""
+    # Multi-line YAML list of schemas to publish. Each entry is {name, path}
+    # where `path` is the source-schema location relative to the calling repo's
+    # checkout.
+    # Required
+    schemas: ""
+```
+
+## Example
+
+Publish the topology schema from the RemotiveTopology release workflow:
+
+```yaml
+publish-schemas:
+  needs: [get-version]
+  runs-on: ubuntu-latest
+  concurrency:
+    group: publish-schemas-topology
+    cancel-in-progress: false
+  steps:
+    - uses: actions/checkout@v4
+
+    - uses: remotivelabs/remotivelabs-topology-actions/sync-schemas@v1
+      with:
+        app-id: ${{ secrets.DOCS_PUSH_APP_ID }}
+        private-key: ${{ secrets.DOCS_PUSH_PRIVATE_KEY }}
+        target-repo: remotivelabs-apis
+        source-component: topology
+        schemas: |
+          - name: topology
+            path: apps/topology/schemas/topology.schema.json
+```
+
+Publish multiple schemas owned by the broker backend in one invocation:
+
+```yaml
+- uses: remotivelabs/remotivelabs-topology-actions/sync-schemas@v1
+  with:
+    app-id: ${{ secrets.DOCS_PUSH_APP_ID }}
+    private-key: ${{ secrets.DOCS_PUSH_PRIVATE_KEY }}
+    target-repo: remotivelabs-apis
+    source-component: broker
+    schemas: |
+      - name: recording
+        path: apps/recording/schemas/recording.schema.json
+      - name: interfaces
+        path: apps/util/schemas/interfaces.schema.json
+      - name: distributed-interfaces
+        path: apps/util/schemas/distributed-interfaces.schema.json
+      - name: metadb
+        path: apps/codec/schemas/metadb.schema.json
+      - name: scripted-db
+        path: apps/scripted/schemas/scripted-db.schema.json
+```
+
+## Output layout in the target repo
+
+After a successful run, the target repo contains:
+
+```
+schemas/
+├── topology.json
+├── recording.json
+├── interfaces.json
+├── distributed-interfaces.json
+├── metadb.json
+└── scripted-db.json
+```
+
+The flat layout matches today's `remotivelabs-apis/schemas/` structure — this action replaces the manual `release-schema.sh` scripts that previously copied schemas into apis by hand. Per-version storage will be layered on in a follow-up.

--- a/sync-schemas/action.yml
+++ b/sync-schemas/action.yml
@@ -1,0 +1,70 @@
+name: Sync schemas to remotivelabs-apis
+description: |
+  Publish a set of JSON schemas owned by one component of a source repo into
+  the central API repo (remotivelabs/remotivelabs-apis). Resets a long-lived
+  schemas-sync branch from main, copies the listed schemas into schemas/, opens
+  a PR, waits for its checks to pass, then merges.
+
+inputs:
+  app-id:
+    description: GitHub App ID for the docs-sync App
+    required: true
+  private-key:
+    description: GitHub App private key (pem contents)
+    required: true
+  target-repo:
+    description: 'Name of the central API repo (e.g. remotivelabs-apis). Assumed to be in the same org as the calling repo.'
+    required: true
+  source-component:
+    description: |
+      Slug identifying the source component owning these schemas (e.g. topology, broker).
+      Used in the sync branch name (schemas-sync/<source-repo>-<component>) so concurrent
+      component releases stay isolated, and in the PR title/commit message.
+    required: true
+  schemas:
+    description: |
+      Multi-line YAML list of schemas to publish. Each entry is {name, path}
+      where `path` is the source-schema location relative to the calling repo's
+      checkout. Example:
+        schemas: |
+          - name: topology
+            path: apps/topology/schemas/topology.schema.json
+          - name: recording
+            path: apps/recording/schemas/recording.schema.json
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Mint GitHub App installation token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ inputs.target-repo }}
+
+    - name: Checkout target repo
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository_owner }}/${{ inputs.target-repo }}
+        token: ${{ steps.app-token.outputs.token }}
+        path: _schemas_target
+        fetch-depth: 0
+
+    - name: Sync, push, PR, watch, merge
+      shell: bash
+      working-directory: _schemas_target
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        SOURCE_REPO: ${{ github.event.repository.name }}
+        SOURCE_SHA: ${{ github.sha }}
+        SOURCE_WORKSPACE: ${{ github.workspace }}
+        SOURCE_COMPONENT: ${{ inputs.source-component }}
+        SCHEMAS_YAML: ${{ inputs.schemas }}
+      run: bash $GITHUB_ACTION_PATH/sync.sh
+
+branding:
+  icon: 'upload-cloud'
+  color: 'blue'

--- a/sync-schemas/sync.sh
+++ b/sync-schemas/sync.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Publish a set of JSON schemas into the central API repo.
+#
+# Run from inside a fresh checkout of the central API repo. Reads inputs
+# from env vars (set by action.yml):
+#
+#   SOURCE_REPO       - source repo name (e.g. signalbroker-server)
+#   SOURCE_SHA        - source commit SHA (for traceability in PR body)
+#   SOURCE_WORKSPACE  - source repo checkout dir (schemas[].path are relative to this)
+#   SOURCE_COMPONENT  - component slug owning these schemas (e.g. topology, broker)
+#   SCHEMAS_YAML      - multi-line YAML list of {name, path} pairs
+#   GH_TOKEN          - App installation token, used for git push and gh pr commands
+#
+# Outcome: a single commit lands on the target's main, containing the listed
+# schemas at schemas/<name>.json (flat layout — Phase 1).
+
+set -euo pipefail
+
+BRANCH="schemas-sync/${SOURCE_REPO}-${SOURCE_COMPONENT}"
+SHORT_SHA="${SOURCE_SHA:0:7}"
+
+git config user.name  "remotivelabs-docs-bot[bot]"
+git config user.email "remotivelabs-docs-bot[bot]@users.noreply.github.com"
+
+# Always start from current main so the PR diff is just this release's schemas.
+git fetch origin main
+git checkout -B "${BRANCH}" origin/main
+
+# Parse SCHEMAS_YAML into tab-separated (name, path) pairs.
+# Minimal YAML — accepts block form and flow form:
+#   - name: topology
+#     path: apps/topology/schemas/topology.schema.json
+#   - { name: recording, path: apps/recording/schemas/recording.schema.json }
+# Avoids PyYAML so we don't need pip install on the runner.
+PAIRS=$(mktemp)
+trap 'rm -f "${PAIRS}"' EXIT
+python3 - "${PAIRS}" <<'PY'
+import os, sys
+
+text = os.environ["SCHEMAS_YAML"]
+out_path = sys.argv[1]
+
+def strip_quote(v):
+    v = v.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+        v = v[1:-1]
+    return v
+
+entries = []
+current = None
+for raw in text.splitlines():
+    line = raw.strip()
+    if not line or line.startswith("#"):
+        continue
+    if line.startswith("- "):
+        if current is not None:
+            entries.append(current)
+            current = None
+        rest = line[2:].strip()
+        if rest.startswith("{") and rest.endswith("}"):
+            entry = {}
+            for part in rest[1:-1].split(","):
+                if ":" not in part:
+                    continue
+                k, _, v = part.partition(":")
+                entry[k.strip()] = strip_quote(v)
+            entries.append(entry)
+        else:
+            current = {}
+            k, _, v = rest.partition(":")
+            current[k.strip()] = strip_quote(v)
+    elif ":" in line and current is not None:
+        k, _, v = line.partition(":")
+        current[k.strip()] = strip_quote(v)
+    else:
+        sys.stderr.write(f"Cannot parse schemas line: {raw!r}\n")
+        sys.exit(1)
+if current is not None:
+    entries.append(current)
+
+if not entries:
+    sys.stderr.write("schemas input parsed empty; nothing to publish\n")
+    sys.exit(1)
+
+with open(out_path, "w") as f:
+    for e in entries:
+        name = e.get("name", "")
+        path = e.get("path", "")
+        if not name or not path:
+            sys.stderr.write(f"Invalid schema entry (missing name or path): {e!r}\n")
+            sys.exit(1)
+        f.write(f"{name}\t{path}\n")
+PY
+
+mkdir -p schemas
+while IFS=$'\t' read -r NAME REL_PATH; do
+  SRC="${SOURCE_WORKSPACE}/${REL_PATH}"
+  if [ ! -f "${SRC}" ]; then
+    echo "Source schema not found: ${SRC}" >&2
+    exit 1
+  fi
+  cp "${SRC}" "schemas/${NAME}.json"
+done < "${PAIRS}"
+
+# No-diff early exit — avoids empty commits and noise.
+git add schemas
+if git diff --cached --quiet; then
+  echo "No schema changes to publish; skipping push/PR/merge."
+  exit 0
+fi
+
+git commit -m "schemas(${SOURCE_REPO}): publish ${SOURCE_COMPONENT} schemas"
+git push --force-with-lease origin "${BRANCH}"
+
+# Idempotent PR open — only consider OPEN PRs as "already exists". The branch
+# is long-lived (no --delete-branch on merge), so prior releases leave merged
+# PRs attached to it; `gh pr view BRANCH` returns those by default and would
+# falsely report the PR as existing, skipping creation for the new commit.
+pr_number=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number')
+if [ -z "${pr_number}" ]; then
+  pr_url=$(gh pr create \
+    --base main \
+    --head "${BRANCH}" \
+    --title "schemas(${SOURCE_REPO}): publish ${SOURCE_COMPONENT} schemas (${SHORT_SHA})" \
+    --body "Automated schema sync from ${SOURCE_REPO}@${SOURCE_SHA}. PR build is the merge gate." \
+    --label "schemas-sync" \
+    --label "source:${SOURCE_REPO}")
+  pr_number="${pr_url##*/}"
+fi
+
+# After force-pushing the branch, GitHub takes a few seconds to enqueue the
+# workflow run and register check runs against the new commit. `gh pr checks
+# --watch` treats "no checks reported" as an error and exits non-zero — so
+# poll until at least one check is visible before watching. Target by PR
+# number to avoid any chance of resolving to a stale merged PR.
+echo "Waiting for PR checks to be registered..."
+attempts=0
+until [ "$(gh pr checks "${pr_number}" --json state --jq 'length' 2>/dev/null || echo 0)" -gt 0 ]; do
+  attempts=$((attempts + 1))
+  if [ "${attempts}" -gt 30 ]; then
+    echo "No checks registered after 5 minutes; proceeding to merge anyway." >&2
+    break
+  fi
+  sleep 10
+done
+
+# Wait for target's PR checks to finish. Non-zero exit if any check fails —
+# that aborts the merge.
+gh pr checks "${pr_number}" --watch
+
+# Rebase merge (target repo's policy). No --delete-branch:
+# schemas-sync/<source>-<component> is a persistent sync channel, force-pushed
+# each release.
+gh pr merge "${pr_number}" --rebase


### PR DESCRIPTION
Adds a composite action that publishes JSON schemas owned by a source component into a central API repo (e.g. remotivelabs-apis), replacing the manual release-schema.sh scripts that copied schemas into the API repo by hand. Per-component branch naming
(schemas-sync/<source-repo>-<component>) keeps concurrent component releases isolated.